### PR TITLE
chore: update yarn lock to match remote execution

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22585,7 +22585,7 @@ __metadata:
 
 "typescript@patch:typescript@4.6.3#~builtin<compat/typescript>":
   version: 4.6.3
-  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=bda367"
+  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
Fixes [ENG-530](https://linear.app/flightcontrol/issue/ENG-530)

## Description

This demo was not being successfully deployed due to a mismatch of yarn.lock files (actual vs expected).